### PR TITLE
Feat/add environment name to context and global variables (#120)

### DIFF
--- a/cli/src/main/java/com/chutneytesting/cli/infrastruture/ExecutionRequestMapper.java
+++ b/cli/src/main/java/com/chutneytesting/cli/infrastruture/ExecutionRequestMapper.java
@@ -43,7 +43,8 @@ public class ExecutionRequestMapper {
             dto.scenario().steps().stream()
                 .map(s -> buildStepDefinitionCore(s, originalEnvironmentObject))
                 .collect(Collectors.toList()),
-            dto.scenario().outputs());
+            dto.scenario().outputs(),
+            originalEnvironmentObject.name());
     }
 
     private static Optional<Target> getTarget(String targetName, Environment originalEnvironmentObject) {
@@ -76,7 +77,8 @@ public class ExecutionRequestMapper {
             dto.steps().stream()
                 .map(s -> buildStepDefinitionCore(s, originalEnvironmentObject))
                 .collect(Collectors.toList()),
-            dto.outputs());
+            dto.outputs(),
+            originalEnvironmentObject.name());
     }
 
     private static StepDefinitionRequestDto getStepDefinitionRequestFromStepDef(StepDefinitionCore definition) {
@@ -98,7 +100,8 @@ public class ExecutionRequestMapper {
             definition.type,
             definition.inputs,
             steps,
-            definition.outputs);
+            definition.outputs,
+            definition.environment);
     }
 
     private static TargetDto toDto(Target target) {

--- a/cli/src/main/java/com/chutneytesting/cli/infrastruture/StepDefinitionCore.java
+++ b/cli/src/main/java/com/chutneytesting/cli/infrastruture/StepDefinitionCore.java
@@ -22,6 +22,11 @@ public class StepDefinitionCore {
     public final Optional<Target> target;
 
     /**
+     * Environment on which to execute the current step.
+     */
+    public final String environment;
+
+    /**
      * Type of the step, should match an extension.
      */
     public final String type;
@@ -47,7 +52,8 @@ public class StepDefinitionCore {
                               StepStrategyDefinitionCore strategy,
                               Map<String, Object> inputs,
                               List<StepDefinitionCore> steps,
-                              Map<String, Object> outputs) {
+                              Map<String, Object> outputs,
+                              String environment) {
         this.gwtType = gwtType;
         this.name = name;
         this.target = target;
@@ -56,6 +62,7 @@ public class StepDefinitionCore {
         this.inputs = inputs != null ? Collections.unmodifiableMap(inputs) : Collections.emptyMap();
         this.steps = steps != null ? Collections.unmodifiableList(steps) : Collections.emptyList();
         this.outputs = outputs != null ? Collections.unmodifiableMap(outputs) : Collections.emptyMap();
+        this.environment = environment;
     }
 
     @Override

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/ExecutionRequestDto.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/ExecutionRequestDto.java
@@ -40,6 +40,7 @@ public class ExecutionRequestDto {
         public final Map<String, Object> inputs;
         public final List<StepDefinitionRequestDto> steps;
         public final Map<String, Object> outputs;
+        public final String environment;
 
         public StepDefinitionRequestDto(
             @JsonProperty("name") String name,
@@ -48,7 +49,8 @@ public class ExecutionRequestDto {
             @JsonProperty("type") String type,
             @JsonProperty("inputs") Map<String, Object> inputs,
             @JsonProperty("steps") List<StepDefinitionRequestDto> steps,
-            @JsonProperty("outputs") Map<String, Object> outputs) {
+            @JsonProperty("outputs") Map<String, Object> outputs,
+            @JsonProperty("environment")String environment) {
 
             this.name = name;
             this.target = target;
@@ -56,6 +58,7 @@ public class ExecutionRequestDto {
             this.inputs = inputs;
             this.steps = steps;
             this.outputs = outputs;
+            this.environment = environment;
 
             this.definition = new StepDefinitionDto(
                 name,
@@ -63,7 +66,8 @@ public class ExecutionRequestDto {
                 type,
                 strategy != null ? strategy.definition : null,
                 inputs, steps != null ? steps.stream().map(r -> r.definition).collect(Collectors.toList()) : Collections.emptyList(),
-                outputs
+                outputs,
+                environment
             );
         }
     }

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/StepDefinitionDto.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/StepDefinitionDto.java
@@ -37,6 +37,8 @@ public class StepDefinitionDto {
 
     public final Map<String, Object> outputs;
 
+    public final String environment;
+
     public final StepStrategyDefinitionDto strategy;
 
     public StepDefinitionDto(String name,
@@ -45,7 +47,8 @@ public class StepDefinitionDto {
                              StepStrategyDefinitionDto strategy,
                              Map<String, Object> inputs,
                              List<StepDefinitionDto> steps,
-                             Map<String, Object> outputs) {
+                             Map<String, Object> outputs,
+                             String environment) {
         this.name = name;
         this.target = target;
         this.type = type;
@@ -53,6 +56,7 @@ public class StepDefinitionDto {
         this.inputs = inputs != null ? Collections.unmodifiableMap(inputs) : Collections.emptyMap();
         this.steps = steps != null ? Collections.unmodifiableList(steps) : Collections.emptyList();
         this.outputs = outputs != null ? Collections.unmodifiableMap(outputs) : Collections.emptyMap();
+        this.environment = environment;
     }
 
     public Optional<TargetDto> getTarget() {

--- a/engine/src/main/java/com/chutneytesting/engine/api/execution/StepDefinitionMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/api/execution/StepDefinitionMapper.java
@@ -38,7 +38,8 @@ class StepDefinitionMapper {
             strategy,
             dto.inputs,
             steps,
-            dto.outputs
+            dto.outputs,
+            dto.environment
         );
     }
 

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/StepDefinition.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/StepDefinition.java
@@ -33,6 +33,8 @@ public class StepDefinition {
 
     public final Map<String, Object> outputs;
 
+    public final String environment;
+
     /**
      * Target on which to execute the current step.
      * Can be null, a step can have no target defined
@@ -50,7 +52,8 @@ public class StepDefinition {
                           StepStrategyDefinition strategy,
                           Map<String, Object> inputs,
                           List<StepDefinition> steps,
-                          Map<String, Object> outputs) {
+                          Map<String, Object> outputs,
+                          String environment) {
         this.name = requireNonNull(name, "The argument <name> must not be null");
         this.type = requireNonNull(type, "The argument <type> must not be null");
 
@@ -60,6 +63,7 @@ public class StepDefinition {
         this.inputs = inputs != null ? Collections.unmodifiableMap(inputs) : Collections.emptyMap();
         this.steps = steps != null ? Collections.unmodifiableList(steps) : Collections.emptyList();
         this.outputs = outputs != null ? Collections.unmodifiableMap(outputs) : Collections.emptyMap();
+        this.environment = environment;
     }
 
     public Optional<Target> getTarget() {

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/FinallyActionMapper.java
@@ -15,6 +15,7 @@ class FinallyActionMapper {
             null,
             finallyAction.inputs(),
             null,
+            null,
             null
         );
     }

--- a/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
+++ b/engine/src/main/java/com/chutneytesting/engine/domain/execution/engine/step/Step.java
@@ -83,6 +83,7 @@ public class Step {
 
         try {
             makeTargetAccessibleForInputEvaluation(scenarioContext, target);
+            makeEnvironmentAccessibleForInputEvaluation(scenarioContext);
             Map<String, Object> evaluatedInputs = unmodifiableMap(dataEvaluator.evaluateNamedDataWithContextVariables(definition.inputs, scenarioContext));
 
             Try
@@ -221,6 +222,10 @@ public class Step {
 
     private void makeTargetAccessibleForInputEvaluation(ScenarioContext scenarioContext, Target target) {
         scenarioContext.put("target", target);
+    }
+
+    private void makeEnvironmentAccessibleForInputEvaluation(ScenarioContext scenarioContext) {
+        scenarioContext.put("environment", definition.environment);
     }
 
     private void copyStepResultsToScenarioContext(StepContextImpl stepContext, ScenarioContext scenarioContext) {

--- a/engine/src/main/java/com/chutneytesting/engine/infrastructure/delegation/ExecutionRequestMapper.java
+++ b/engine/src/main/java/com/chutneytesting/engine/infrastructure/delegation/ExecutionRequestMapper.java
@@ -37,7 +37,8 @@ class ExecutionRequestMapper {
             definition.type,
             definition.inputs,
             steps,
-            definition.outputs);
+            definition.outputs,
+            definition.environment);
     }
 
     private static TargetDto extractTarget(StepDefinition definition) {

--- a/engine/src/test/java/com/chutneytesting/ExecutionSpringConfigurationTest.java
+++ b/engine/src/test/java/com/chutneytesting/ExecutionSpringConfigurationTest.java
@@ -147,7 +147,8 @@ public class ExecutionSpringConfigurationTest {
             "error",
             Collections.emptyMap(),
             Collections.emptyList(),
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            ""
         );
         ExecutionRequestDto requestDto = new ExecutionRequestDto(stepDefinition);
 
@@ -167,7 +168,8 @@ public class ExecutionSpringConfigurationTest {
                   "success",
                   Collections.emptyMap(),
                   Collections.emptyList(),
-                  Collections.emptyMap()
+                  Collections.emptyMap(),
+            ""
               );
     }
 
@@ -183,7 +185,8 @@ public class ExecutionSpringConfigurationTest {
             null,
             Collections.emptyMap(),
             steps,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            ""
         );
     }
 
@@ -195,7 +198,8 @@ public class ExecutionSpringConfigurationTest {
             "sleep",
             Maps.newHashMap("duration", "500 ms"),
             null,
-            Collections.emptyMap()
+            Collections.emptyMap(),
+            ""
         );
     }
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/DefaultExecutionEngineTest.java
@@ -34,6 +34,7 @@ public class DefaultExecutionEngineTest {
     private final StepDataEvaluator dataEvaluator = mock(StepDataEvaluator.class, Answers.RETURNS_DEEP_STUBS);
     private final StepExecutionStrategies stepExecutionStrategies = mock(StepExecutionStrategies.class, Answers.RETURNS_DEEP_STUBS);
     private final DelegationService delegationService = mock(DelegationService.class, Answers.RETURNS_DEEP_STUBS);
+    private final String fakeEnvironment = "";
 
     @Test
     public void runtime_exception_should_be_catch_by_fault_barrier() {
@@ -46,7 +47,7 @@ public class DefaultExecutionEngineTest {
         DefaultExecutionEngine engine = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter);
         StrategyProperties strategyProperties = new StrategyProperties();
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, fakeEnvironment);
 
         //When
         Long executionId = engine.execute(stepDefinition, ScenarioExecution.createScenarioExecution());
@@ -70,7 +71,7 @@ public class DefaultExecutionEngineTest {
 
         StrategyProperties strategyProperties = new StrategyProperties();
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, fakeEnvironment);
 
         ScenarioExecution mockScenarioExecution = mock(ScenarioExecution.class);
 
@@ -94,7 +95,7 @@ public class DefaultExecutionEngineTest {
 
         StrategyProperties strategyProperties = new StrategyProperties();
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, fakeEnvironment);
 
         ScenarioExecution scenarioExecution = ScenarioExecution.createScenarioExecution();
         scenarioExecution.registerFinallyAction(FinallyAction.Builder.forAction("final").build());
@@ -123,7 +124,7 @@ public class DefaultExecutionEngineTest {
         DefaultExecutionEngine engineUnderTest = new DefaultExecutionEngine(dataEvaluator, stepExecutionStrategies, delegationService, reporter);
         StrategyProperties strategyProperties = new StrategyProperties();
         StepStrategyDefinition strategyDefinition = new StepStrategyDefinition("retry", strategyProperties);
-        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null);
+        StepDefinition stepDefinition = new StepDefinition("name", null, "type", strategyDefinition, null, null, null, fakeEnvironment);
 
         ScenarioExecution mockScenarioExecution = mock(ScenarioExecution.class);
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/engine/step/StepTest.java
@@ -41,6 +41,7 @@ public class StepTest {
 
     private StepDataEvaluator dataEvaluator = new StepDataEvaluator(new SpelFunctions());
     private Target fakeTarget = TargetImpl.NONE;
+    private String environment = "";
 
     @Test
     public void stop_should_not_execute_test() {
@@ -94,7 +95,7 @@ public class StepTest {
         outputs.put("aValue", "${#aValueToEvaluate}");
         outputs.put("anotherValue", "${#anotherValueToEvaluate}");
 
-        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, outputs);
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, outputs,environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, Optional.empty(), stepExecutor, Lists.emptyList());
         ScenarioContextImpl scenarioContext = new ScenarioContextImpl();
 
@@ -133,7 +134,7 @@ public class StepTest {
         outputs.put("anAliasForReuse", "${#aResultKeySetByATask}");
         outputs.put("anotherAliasForReuse", "${#anotherResultKeySetByATask}");
 
-        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, outputs);
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, outputs,environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, Optional.empty(), fakeRemoteStepExecutor, Lists.emptyList());
         ScenarioContextImpl scenarioContext = new ScenarioContextImpl();
 
@@ -147,14 +148,16 @@ public class StepTest {
     }
 
     @Test
-    public void target_is_set_in_scenario_context_in_order_to_be_used_by_evaluated_inputs() {
+    public void target_and_environment_are_set_in_scenario_context_in_order_to_be_used_by_evaluated_inputs() {
         // Given
         TargetImpl fakeTarget = TargetImpl.builder().withName("fakeTargetName").build();
+        String environment = "FakeTestEnvironment";
 
         Map<String, Object> inputs = new HashMap<>();
         inputs.put("targetName", "${#target.name}");
+        inputs.put("currentEnvironment", "${#environment}");
 
-        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", this.fakeTarget, "taskType", null, inputs, null, null);
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", this.fakeTarget, "taskType", null, inputs, null, null,environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, Optional.of(fakeTarget), mock(StepExecutor.class), Lists.emptyList());
 
         // When
@@ -162,9 +165,11 @@ public class StepTest {
 
         // Then
         StepContext context = (StepContext) ReflectionTestUtils.getField(step, "stepContext");
-        assertThat(context.getEvaluatedInputs()).hasSize(1);
+        assertThat(context.getEvaluatedInputs()).hasSize(2);
         assertThat(context.getEvaluatedInputs()).containsKeys("targetName");
         assertThat(context.getEvaluatedInputs().get("targetName")).isEqualTo("fakeTargetName");
+        assertThat(context.getEvaluatedInputs()).containsKeys("currentEnvironment");
+        assertThat(context.getEvaluatedInputs().get("currentEnvironment")).isEqualTo(environment);
     }
 
     @Test
@@ -205,7 +210,7 @@ public class StepTest {
 
     @Test
     public void should_not_compute_substeps_status_if_current_status_is_failure() {
-        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null);
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null,environment);
         Step step = new Step(dataEvaluator, fakeStepDefinition, Optional.empty(), mock(StepExecutor.class), Lists.list(mock(Step.class), mock(Step.class)));
         step.failure("...");
         assertThat(step.status()).isEqualTo(Status.FAILURE);
@@ -238,7 +243,7 @@ public class StepTest {
     }
 
     private Step buildEmptyStep(StepExecutor stepExecutor) {
-        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null);
+        StepDefinition fakeStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, null, null,environment);
         return new Step(dataEvaluator, fakeStepDefinition, Optional.empty(), stepExecutor, Lists.emptyList());
     }
 

--- a/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/DefaultStepExecutionStrategyTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/execution/strategies/DefaultStepExecutionStrategyTest.java
@@ -124,7 +124,7 @@ public class DefaultStepExecutionStrategyTest {
     }
 
     private StepDefinition buildStepDef(String name, String type) {
-        return new StepDefinition(name, null, type, null, null, null, null);
+        return new StepDefinition(name, null, type, null, null, null, null,"");
     }
 
     private static void visit(Step step, Consumer<Step> action) {

--- a/engine/src/test/java/com/chutneytesting/engine/domain/report/ReporterTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/domain/report/ReporterTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 public class ReporterTest {
 
     private Target fakeTarget = TargetImpl.NONE;
+    private String environment = "";
     private StepDataEvaluator dataEvaluator = new StepDataEvaluator(new SpelFunctions());
 
     private Reporter sut;
@@ -139,16 +140,16 @@ public class ReporterTest {
 
     private Step buildFakeScenario() {
         List<StepDefinition> subSubSteps = new ArrayList<>();
-        StepDefinition subSubStepDef1 = new StepDefinition("fakeStep1", fakeTarget, "taskType", null, null, null, null);
-        StepDefinition subSubStepDef2 = new StepDefinition("fakeStep2", fakeTarget, "taskType", null, null, null, null);
+        StepDefinition subSubStepDef1 = new StepDefinition("fakeStep1", fakeTarget, "taskType", null, null, null, null, environment);
+        StepDefinition subSubStepDef2 = new StepDefinition("fakeStep2", fakeTarget, "taskType", null, null, null, null, environment);
         subSubSteps.add(subSubStepDef1);
         subSubSteps.add(subSubStepDef2);
-        StepDefinition subStepDef1 = new StepDefinition("fakeParentStep", fakeTarget, "taskType", null, null, subSubSteps, null);
-        StepDefinition subStepDef2 = new StepDefinition("fakeParentEmptyStep", fakeTarget, "taskType", null, null, null, null);
+        StepDefinition subStepDef1 = new StepDefinition("fakeParentStep", fakeTarget, "taskType", null, null, subSubSteps, null, environment);
+        StepDefinition subStepDef2 = new StepDefinition("fakeParentEmptyStep", fakeTarget, "taskType", null, null, null, null, environment);
         List<StepDefinition> steps = new ArrayList<>();
         steps.add(subStepDef1);
         steps.add(subStepDef2);
-        StepDefinition rootStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, steps, null);
+        StepDefinition rootStepDefinition = new StepDefinition("fakeScenario", fakeTarget, "taskType", null, null, steps, null, environment);
 
         return buildStep(rootStepDefinition);
     }

--- a/engine/src/test/java/com/chutneytesting/engine/infrastructure/delegation/HttpClientTest.java
+++ b/engine/src/test/java/com/chutneytesting/engine/infrastructure/delegation/HttpClientTest.java
@@ -123,7 +123,8 @@ public class HttpClientTest {
             strategy,
             new HashMap<>(),
             Collections.emptyList(),
-            new HashMap<>());
+            new HashMap<>(),
+            "ENV");
     }
 
     public ObjectMapper objectMapper() {

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/ComposableTestCaseDataSetPreProcessor.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/ComposableTestCaseDataSetPreProcessor.java
@@ -26,13 +26,25 @@ public class ComposableTestCaseDataSetPreProcessor implements TestCasePreProcess
     }
 
     @Override
-    public ComposableTestCase apply(ComposableTestCase testCase) {
+    public ComposableTestCase apply(ComposableTestCase testCase, String environment) {
         Map<String, String> globalVariable = globalvarRepository.getFlatMap();
+        makeEnvironmentNameAsGlobalVariable(globalVariable, environment);
         return new ComposableTestCase(
             testCase.id,
             applyToMetadata(testCase.metadata, testCase.dataSet, globalVariable),
             applyToScenario(testCase.composableScenario, testCase.dataSet, globalVariable),
             testCase.dataSet);
+    }
+
+    public ComposableTestCase applyOnStrategy(ComposableTestCase testCase, String environment) {
+        Map<String, String> globalVariable = globalvarRepository.getFlatMap();
+        makeEnvironmentNameAsGlobalVariable(globalVariable,environment);
+        Map<String,String> testCaseDataSet = applyOnCurrentStepDataSet(testCase.dataSet, emptyMap(), globalVariable);
+        return new ComposableTestCase(
+            testCase.id,
+            testCase.metadata,
+            applyOnStrategy(testCase.composableScenario, testCaseDataSet, globalVariable),
+            testCaseDataSet);
     }
 
     private TestCaseMetadata applyToMetadata(TestCaseMetadata metadata, Map<String, String> dataSet, Map<String, String> globalVariable) {
@@ -85,16 +97,6 @@ public class ComposableTestCaseDataSetPreProcessor implements TestCasePreProcess
             }));
 
         return scopedDataset;
-    }
-
-    ComposableTestCase applyOnStrategy(ComposableTestCase testCase) {
-        Map<String, String> globalVariable = globalvarRepository.getFlatMap();
-        Map<String,String> testCaseDataSet = applyOnCurrentStepDataSet(testCase.dataSet, emptyMap(), globalVariable);
-        return new ComposableTestCase(
-            testCase.id,
-            testCase.metadata,
-            applyOnStrategy(testCase.composableScenario, testCaseDataSet, globalVariable),
-            testCaseDataSet);
     }
 
     private ComposableScenario applyOnStrategy(ComposableScenario composableScenario, Map<String, String> testCaseDataSet, Map<String, String> globalVariable) {

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/ComposableTestCasePreProcessor.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/ComposableTestCasePreProcessor.java
@@ -17,7 +17,7 @@ public class ComposableTestCasePreProcessor implements TestCasePreProcessor<Comp
     }
 
     @Override
-    public ComposableTestCase apply(ComposableTestCase testCase) {
-        return dataSetPreProcessor.apply(loopPreProcessor.apply(dataSetPreProcessor.applyOnStrategy(testCase)));
+    public ComposableTestCase apply(ComposableTestCase testCase, String environment) {
+        return dataSetPreProcessor.apply(loopPreProcessor.apply(dataSetPreProcessor.applyOnStrategy(testCase, environment)), environment);
     }
 }

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/GwtDataSetPreProcessor.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/GwtDataSetPreProcessor.java
@@ -19,7 +19,7 @@ public class GwtDataSetPreProcessor implements TestCasePreProcessor<GwtTestCase>
     }
 
     @Override
-    public GwtTestCase apply(GwtTestCase testCase) {
+    public GwtTestCase apply(GwtTestCase testCase, String environment) {
         return GwtTestCase.builder()
             .withMetadata(testCase.metadata)
             .withDataSet(testCase.dataSet)

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/RawDataSetPreProcessor.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/RawDataSetPreProcessor.java
@@ -15,7 +15,7 @@ public class RawDataSetPreProcessor implements TestCasePreProcessor<RawTestCase>
     }
 
     @Override
-    public RawTestCase apply(RawTestCase testCase) {
+    public RawTestCase apply(RawTestCase testCase, String environment) {
         return RawTestCase.builder()
             .withMetadata(testCase.metadata)
             .withScenario(replaceParams(testCase.content, globalvarRepository.getFlatMap(), testCase.dataSet(), StringEscapeUtils::escapeJson))

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/TestCasePreProcessor.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/TestCasePreProcessor.java
@@ -8,7 +8,7 @@ import java.util.function.Function;
 
 public interface TestCasePreProcessor<T extends TestCase> {
 
-    T apply(T testCase);
+    T apply(T testCase, String environment);
 
     default boolean test(T testCase) {
         Type type = ((ParameterizedType) getClass().getGenericInterfaces()[0]).getActualTypeArguments()[0];
@@ -31,6 +31,12 @@ public interface TestCasePreProcessor<T extends TestCase> {
             stringReplaced = stringReplaced.replace("**" + entry.getKey() + "**", escapeValueFunction.apply(entry.getValue()));
         }
         return stringReplaced;
+    }
+
+    default void makeEnvironmentNameAsGlobalVariable(Map<String, String> globalVariable, String environment) {
+        if(environment != null && !environment.isEmpty()){
+            globalVariable.put("environment", environment);
+        }
     }
 
 }

--- a/server/src/main/java/com/chutneytesting/execution/domain/compiler/TestCasePreProcessors.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/compiler/TestCasePreProcessors.java
@@ -12,11 +12,11 @@ public class TestCasePreProcessors {
         this.processors = Collections.unmodifiableList(processors);
     }
 
-    public <T extends TestCase> T apply(final T testCase) {
+    public <T extends TestCase> T apply(final T testCase, String environment) {
         T tmp = testCase;
         for (TestCasePreProcessor<T> p : processors) {
             if(p.test(tmp)) {
-                tmp = p.apply(tmp);
+                tmp = p.apply(tmp,environment);
             }
         }
         return tmp;

--- a/server/src/main/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngine.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngine.java
@@ -77,7 +77,7 @@ public class ScenarioExecutionEngine {
     }
 
     private ScenarioExecutionReport simpleSyncExecution(String environment, TestCase testCase) {
-        TestCase testCaseProcessed = testCasePreProcessors.apply(testCase);
+        TestCase testCaseProcessed = testCasePreProcessors.apply(testCase,environment);
 
         StepExecutionReportCore finalStepReport = executionEngine.execute(new ExecutionRequest(testCaseProcessed, environment));
         return new ScenarioExecutionReport(0L, testCaseProcessed.metadata().title(), environment, finalStepReport);

--- a/server/src/main/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngineAsync.java
+++ b/server/src/main/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngineAsync.java
@@ -88,7 +88,7 @@ public class ScenarioExecutionEngineAsync {
         // Before execution check
         verifyScenarioNotAlreadyRunning(executionRequest.testCase.id());
         // Compile testcase for execution
-        ExecutionRequest executionRequestProcessed = new ExecutionRequest(testCasePreProcessors.apply(executionRequest.testCase), executionRequest.environment);
+        ExecutionRequest executionRequestProcessed = new ExecutionRequest(testCasePreProcessors.apply(executionRequest.testCase,executionRequest.environment), executionRequest.environment);
         // Initialize execution history
         ExecutionHistory.Execution storedExecution = storeInitialReport(executionRequest.testCase.id(), executionRequest.testCase.metadata().title(), executionRequest.environment);
         // Start engine execution

--- a/server/src/main/java/com/chutneytesting/execution/infra/execution/ExecutionRequestMapper.java
+++ b/server/src/main/java/com/chutneytesting/execution/infra/execution/ExecutionRequestMapper.java
@@ -103,7 +103,8 @@ public class ExecutionRequestMapper {
             definition.type,
             definition.inputs,
             steps,
-            definition.outputs);
+            definition.outputs,
+            env);
     }
 
     private StepDefinitionRequestDto convertGwt(ExecutionRequest executionRequest) {
@@ -115,7 +116,8 @@ public class ExecutionRequestMapper {
             null,
             emptyMap(),
             convert(gwtTestCase.scenario.steps(), executionRequest.environment),
-            emptyMap()
+            emptyMap(),
+            executionRequest.environment
         );
     }
 
@@ -133,7 +135,8 @@ public class ExecutionRequestMapper {
             step.implementation.map(i -> i.type).orElse(""),
             step.implementation.map(i -> i.inputs).orElse(emptyMap()),
             convert(step.subSteps, env),
-            step.implementation.map(i -> i.outputs).orElse(emptyMap())
+            step.implementation.map(i -> i.outputs).orElse(emptyMap()),
+            env
         );
     }
 
@@ -210,7 +213,8 @@ public class ExecutionRequestMapper {
                 null,
                 null,
                 convertComposableSteps(composableTestCase.composableScenario.functionalSteps, executionRequest.environment),
-                null
+                null,
+                executionRequest.environment
             );
         } catch (Exception e) {
             throw new ScenarioConversionException(composableTestCase.metadata().id(), e);
@@ -231,7 +235,8 @@ public class ExecutionRequestMapper {
             implementation.map(ComposableImplementation::type).orElse(""),
             implementation.map(ComposableImplementation::inputs).orElse(emptyMap()),
             functionalStep.steps.stream().map(f -> convert(f, env)).collect(Collectors.toList()),
-            implementation.map(ComposableImplementation::outputs).orElse(emptyMap())
+            implementation.map(ComposableImplementation::outputs).orElse(emptyMap()),
+            env
         );
     }
 

--- a/server/src/test/java/com/chutneytesting/execution/domain/compiler/ComposableTestCaseDataSetPreProcessorTest.java
+++ b/server/src/test/java/com/chutneytesting/execution/domain/compiler/ComposableTestCaseDataSetPreProcessorTest.java
@@ -41,7 +41,8 @@ public class ComposableTestCaseDataSetPreProcessorTest {
         String actionImplementation = "{\"identifier\": \"http-get\", \"target\": \"%1$s\", \"inputs\": []}";
         String stepName = "step with %1$s - %2$s - %3$s";
         String testCaseTitle = "test case testCaseTitle with parameter %1$s";
-        String testCaseDescription = "test case description with parameter %1$s";
+        String testCaseDescription = "test case description with parameter %1$s - %2$s";
+        String environment = "exec env";
 
         Strategy retryStrategy =
             new Strategy("retry", Maps.of("timeout", "10 s", "delay", "10 s"));
@@ -90,7 +91,7 @@ public class ComposableTestCaseDataSetPreProcessorTest {
             TestCaseMetadataImpl.builder()
                 .withCreationDate(Instant.now())
                 .withTitle(format(testCaseTitle, "**testcase title**"))
-                .withDescription(format(testCaseDescription, "**testcase description**"))
+                .withDescription(format(testCaseDescription, "**testcase description**", "**environment**"))
                 .build(),
             ComposableScenario.builder()
                 .withFunctionalSteps(
@@ -113,12 +114,12 @@ public class ComposableTestCaseDataSetPreProcessorTest {
 
         ComposableTestCaseDataSetPreProcessor sut = new ComposableTestCaseDataSetPreProcessor(globalvarRepository);
         // When
-        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase);
+        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase, environment);
 
         // Then
         assertThat(composableTestCaseProcessed.id()).isEqualTo(composableTestCase.id());
         assertThat(composableTestCaseProcessed.metadata.title()).isEqualTo(format(testCaseTitle, dataSet.get("testcase title")));
-        assertThat(composableTestCaseProcessed.metadata.description()).isEqualTo(format(testCaseDescription, dataSet.get("testcase description")));
+        assertThat(composableTestCaseProcessed.metadata.description()).isEqualTo(format(testCaseDescription, dataSet.get("testcase description"), environment));
 
         FunctionalStep firstStep = composableTestCaseProcessed.composableScenario.functionalSteps.get(0);
         assertThat(firstStep.name).isEqualTo(format(stepName, dataSet.get("testcase param"), dataSet.get("step target"), firstStep.dataSet.get("target")));
@@ -150,6 +151,7 @@ public class ComposableTestCaseDataSetPreProcessorTest {
         );
         assertStepActions(actionName, thirdStep, step.steps.get(2).dataSet.get("target"), retryStrategy);
     }
+
 
     private FunctionalStep buildStepFromActionWithDataSet(FunctionalStep action, String targetDataSetValue) {
         return FunctionalStep.builder()

--- a/server/src/test/java/com/chutneytesting/execution/domain/compiler/ComposableTestCasePreProcessorTest.java
+++ b/server/src/test/java/com/chutneytesting/execution/domain/compiler/ComposableTestCasePreProcessorTest.java
@@ -31,6 +31,7 @@ public class ComposableTestCasePreProcessorTest {
 
     private GlobalvarRepository globalvarRepository;
     private ObjectMapper objectMapper = new WebConfiguration().objectMapper();
+    private String environment = "exec env";
 
     private ComposableTestCasePreProcessor sut;
 
@@ -50,7 +51,7 @@ public class ComposableTestCasePreProcessorTest {
         final String SECOND_ITERATION_VALUE = "iteration_2";
 
         when(globalvarRepository.getFlatMap())
-            .thenReturn(singletonMap(GLOBAL_PARAMETER, "[{\"" + VALUE + "\":\"" + FIRST_ITERATION_VALUE + "\"}, {\"value\":\"" + SECOND_ITERATION_VALUE + "\"}]"));
+            .thenReturn(new HashMap<>(Maps.of(GLOBAL_PARAMETER, "[{\"" + VALUE + "\":\"" + FIRST_ITERATION_VALUE + "\"}, {\"value\":\"" + SECOND_ITERATION_VALUE + "\"}]")));
 
         sut = new ComposableTestCasePreProcessor(objectMapper, globalvarRepository);
 
@@ -77,7 +78,7 @@ public class ComposableTestCasePreProcessorTest {
         ComposableTestCase composableTestase = new ComposableTestCase("0", TestCaseMetadataImpl.builder().build(), composableScenario);
 
         // When
-        ComposableTestCase actual = sut.apply(composableTestase);
+        ComposableTestCase actual = sut.apply(composableTestase, environment);
 
         // Then
         assertThat(actual.composableScenario.functionalSteps.size()).isEqualTo(1);
@@ -97,7 +98,7 @@ public class ComposableTestCasePreProcessorTest {
         final String SECOND_ITERATION_VALUE = "iteration_2";
 
         when(globalvarRepository.getFlatMap())
-            .thenReturn(singletonMap(GLOBAL_PARAMETER, "[{\"" + VALUE + "\":\"" + FIRST_ITERATION_VALUE + "\"}, {\"value\":\"" + SECOND_ITERATION_VALUE + "\"}]"));
+            .thenReturn(new HashMap<>(Maps.of(GLOBAL_PARAMETER, "[{\"" + VALUE + "\":\"" + FIRST_ITERATION_VALUE + "\"}, {\"value\":\"" + SECOND_ITERATION_VALUE + "\"}]")));
 
         sut = new ComposableTestCasePreProcessor(objectMapper, globalvarRepository);
 
@@ -125,7 +126,7 @@ public class ComposableTestCasePreProcessorTest {
         ComposableTestCase composableTestase = new ComposableTestCase("0", TestCaseMetadataImpl.builder().build(), composableScenario, dataset);
 
         // When
-        ComposableTestCase actual = sut.apply(composableTestase);
+        ComposableTestCase actual = sut.apply(composableTestase, environment);
 
         // Then
         assertThat(actual.composableScenario.functionalSteps.size()).isEqualTo(1);
@@ -220,7 +221,7 @@ public class ComposableTestCasePreProcessorTest {
             dataSet);
 
         // When
-        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase);
+        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase, environment);
 
         // Then
         assertThat(composableTestCaseProcessed.id()).isEqualTo(composableTestCase.id());
@@ -349,7 +350,7 @@ public class ComposableTestCasePreProcessorTest {
                 .build(),
             dataSet);
 
-        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase);
+        final ComposableTestCase composableTestCaseProcessed = sut.apply(composableTestCase, environment);
 
         // Then
         assertThat(composableTestCaseProcessed.id()).isEqualTo(composableTestCase.id());

--- a/server/src/test/java/com/chutneytesting/execution/domain/compiler/DataSetPreProcessorTest.java
+++ b/server/src/test/java/com/chutneytesting/execution/domain/compiler/DataSetPreProcessorTest.java
@@ -44,7 +44,7 @@ public class DataSetPreProcessorTest {
             .build();
 
         // When
-        RawTestCase actual = dataSetPreProcessor.apply(fakeTestCase);
+        RawTestCase actual = dataSetPreProcessor.apply(fakeTestCase,null);
 
         // Then
         String expectedContent = "a blabla step with a value and another value and value1";
@@ -85,7 +85,7 @@ public class DataSetPreProcessorTest {
         GwtDataSetPreProcessor dataSetPreProcessor = new GwtDataSetPreProcessor(new GwtScenarioMapper(), globalvarRepository);
 
         // When
-        GwtTestCase actual = dataSetPreProcessor.apply(parameterizedTestCase);
+        GwtTestCase actual = dataSetPreProcessor.apply(parameterizedTestCase,null);
 
         // Then
         GwtTestCase evaluatedTestCase = GwtTestCase.builder()

--- a/server/src/test/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngineAsyncTest.java
+++ b/server/src/test/java/com/chutneytesting/execution/domain/scenario/ScenarioExecutionEngineAsyncTest.java
@@ -107,7 +107,7 @@ public class ScenarioExecutionEngineAsyncTest {
         final long executionId = 3L;
 
         when(executionStateRepository.runningState(scenarioId)).thenReturn(Optional.empty());
-        when(testCasePreProcessors.apply(any())).thenReturn(testCase);
+        when(testCasePreProcessors.apply(any(),any())).thenReturn(testCase);
         when(executionEngine.executeAndFollow(any())).thenReturn(Pair.of(Observable.empty(), 0L));
 
         ExecutionHistory.Execution storedExecution = stubHistoryExecution(scenarioId, executionId);
@@ -129,7 +129,7 @@ public class ScenarioExecutionEngineAsyncTest {
 
         // Then
         verify(executionStateRepository).runningState(scenarioId);
-        verify(testCasePreProcessors).apply(any(RawTestCase.class));
+        verify(testCasePreProcessors).apply(any(RawTestCase.class),any());
         verify(executionEngine).executeAndFollow(any());
         ArgumentCaptor<ExecutionHistory.DetachedExecution> argumentCaptor = ArgumentCaptor.forClass(ExecutionHistory.DetachedExecution.class);
         verify(executionHistoryRepository).store(eq(scenarioId), argumentCaptor.capture());
@@ -202,7 +202,7 @@ public class ScenarioExecutionEngineAsyncTest {
         final RawTestCase testCase = emptyTestCase();
 
         when(executionStateRepository.runningState(scenarioId)).thenReturn(Optional.empty());
-        when(testCasePreProcessors.apply(any())).thenReturn(testCase);
+        when(testCasePreProcessors.apply(any(),any())).thenReturn(testCase);
 
         stubHistoryExecution(scenarioId, executionId);
         final List<StepExecutionReportCore> reportsList = stubEngineExecution(executionId, 0).getMiddle();


### PR DESCRIPTION
* tech(engine+server+cli): add environment name to context

* tech(core): add environment name to global variables

* fix : add braces

* fix: use definition.environment + set default env to null rather than empty string

Co-authored-by: REDOUANE BENYOUSSEF <redouane-externe.benyoussef@enedis.fr>